### PR TITLE
Remove 'declare variables at top' rule

### DIFF
--- a/engineering/javascript.md
+++ b/engineering/javascript.md
@@ -396,44 +396,41 @@ const b = 2;
 const a = 1, b = 2;
 ```
 
-+ Declare variables at the top of their block scope.
+Assign variables where you need them, but place them in a reasonable place.
+
+> Why? `let` and `const` are block scoped and not function scoped.
 
 ```javascript
-function mutate(thing) {
-  return new Promise((resolve) => {
-    resolve(thing);
-  });
+// bad - unnecessary function call
+function checkName(hasName) {
+  const name = getName();
+
+  if (hasName === 'test') {
+    return false;
+  }
+
+  if (name === 'test') {
+    this.setName('');
+    return false;
+  }
+
+  return name;
 }
 
 // good
-function bar() {
-  const itemToPush = 'foo';
-  const coolList = [1, 2, 3, 4, 5, 6];
-  let updatedList = coolList.filter((item) => {
-    return (item % 2) === 0;
-  });
+function checkName(hasName) {
+  if (hasName === 'test') {
+    return false;
+  }
 
-  mutate(updatedList).then((list) => {
-    updatedList = list.push(itemToPush);
-  });
+  const name = getName();
 
-  return updatedList;
-}
+  if (name === 'test') {
+    this.setName('');
+    return false;
+  }
 
-// bad
-function bar() {
-  let updatedList = coolList.filter((item) => {
-    return (item % 2) === 0;
-  });
-
-  const coolList = [1, 2, 3, 4, 5, 6];
-
-  mutate(updatedList).then((list) => {
-    updatedList = list.push(result);
-  });
-
-  const result = 'foo';
-  return updatedList;
+  return name;
 }
 ```
 


### PR DESCRIPTION
Propose that we remove the guideline that suggests declaring variables at the top as it is outdated and reduces readability for longer, more complex functions.

References for discussion:

- [StackOverflow discussion on the topic](https://stackoverflow.com/questions/5053073/is-defining-every-variable-at-the-top-always-the-best-approach)
  - In particular, I find the example in the top-voted answer about the separation of when variables are declared and used to be the thing I'm struggling with. Declaring a variable 20 lines before it's used (vs right before the few lines of code that use it) makes the code harder to read
- [Medium article on the topic](https://medium.com/@bluepnume/theres-no-need-to-define-all-javascript-vars-once-at-the-top-of-a-function-and-there-hasn-t-been-a66b31f21822)


In searching around, it seems that a majority people find putting variables at the top to be a bad practice.
